### PR TITLE
Add uniquely random preset selection as an option

### DIFF
--- a/HarmonyPatches/SceneTransitionPatch.cs
+++ b/HarmonyPatches/SceneTransitionPatch.cs
@@ -58,6 +58,20 @@ namespace BSExtraColorPresets.HarmonyPatches
                 var randomPresetIndex = random.Next(PluginConfig.Instance.ExtraColorPresetsV2.Count());
                 selectedPreset = PluginConfig.Instance.ExtraColorPresetsV2[randomPresetIndex];
             }
+            else if (PluginConfig.Instance.SelectedPresetId == MinimalExtraColorPreset.randomUniqueItem.colorSchemeId)
+            {
+                Plugin.Log.Info($"Preset selection set to uniquely random, picking from available presets…");
+                var randomPresetIndex = random.Next(Plugin.ExtraColorPresetsUniqueSelectable.Count());
+                selectedPreset = Plugin.ExtraColorPresetsUniqueSelectable[randomPresetIndex];
+                
+                Plugin.ExtraColorPresetsUniqueSelectable.RemoveAt(randomPresetIndex);
+                Plugin.Log.Info(Plugin.ExtraColorPresetsUniqueSelectable.Count.ToString() + " presets available");
+                if (!Plugin.ExtraColorPresetsUniqueSelectable.Any())
+                {
+                    Plugin.Log.Info($"Ran out of selectable presets, copying the list again…");
+                    Plugin.ExtraColorPresetsUniqueSelectable = PluginConfig.Instance.ExtraColorPresetsV2.GetRange(0, PluginConfig.Instance.ExtraColorPresetsV2.Count);
+                }
+            }
             else
             {
                 selectedPreset = PluginConfig.Instance.ExtraColorPresetsV2.Find(preset => preset.colorSchemeId == PluginConfig.Instance.SelectedPresetId);

--- a/HarmonyPatches/SceneTransitionPatch.cs
+++ b/HarmonyPatches/SceneTransitionPatch.cs
@@ -62,14 +62,16 @@ namespace BSExtraColorPresets.HarmonyPatches
             {
                 Plugin.Log.Info($"Preset selection set to uniquely random, picking from available presets…");
                 var randomPresetIndex = random.Next(Plugin.ExtraColorPresetsUniqueSelectable.Count());
-                selectedPreset = Plugin.ExtraColorPresetsUniqueSelectable[randomPresetIndex];
+                var selectedPresetID = Plugin.ExtraColorPresetsUniqueSelectable[randomPresetIndex];
+
+                selectedPreset = PluginConfig.Instance.ExtraColorPresetsV2.Find(preset => preset.colorSchemeId == selectedPresetID);
                 
                 Plugin.ExtraColorPresetsUniqueSelectable.RemoveAt(randomPresetIndex);
                 Plugin.Log.Info(Plugin.ExtraColorPresetsUniqueSelectable.Count.ToString() + " presets available");
                 if (!Plugin.ExtraColorPresetsUniqueSelectable.Any())
                 {
                     Plugin.Log.Info($"Ran out of selectable presets, copying the list again…");
-                    Plugin.ExtraColorPresetsUniqueSelectable = PluginConfig.Instance.ExtraColorPresetsV2.GetRange(0, PluginConfig.Instance.ExtraColorPresetsV2.Count);
+                    Plugin.ReinitUniqueSelectables();
                 }
             }
             else

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -61,11 +61,7 @@ namespace BSExtraColorPresets
 
         public static void ReinitUniqueSelectables()
         {
-            ExtraColorPresetsUniqueSelectable = new List<string>();
-            PluginConfig.Instance.ExtraColorPresetsV2.ForEach(scheme =>
-            {
-                ExtraColorPresetsUniqueSelectable.Add(scheme.colorSchemeId);
-            });
+            ExtraColorPresetsUniqueSelectable = PluginConfig.Instance.ExtraColorPresetsV2.ConvertAll(scheme => scheme.colorSchemeId);
         }
 
         [OnStart]

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -27,7 +27,7 @@ namespace BSExtraColorPresets
 
         private static readonly HarmonyLib.Harmony Harmony = new HarmonyLib.Harmony($"art.djdavid98.{PluginName}");
 
-        public static List<ExtraColorPresetV2> ExtraColorPresetsUniqueSelectable;
+        public static List<string> ExtraColorPresetsUniqueSelectable;
 
         [Init]
         /// <summary>
@@ -55,8 +55,17 @@ namespace BSExtraColorPresets
                 Log.Debug("Adding initial blank preset");
                 PluginConfig.Instance.ExtraColorPresetsV2.Add(new ExtraColorPresetV2());
             }
+            
+            ReinitUniqueSelectables();
+        }
 
-            ExtraColorPresetsUniqueSelectable = PluginConfig.Instance.ExtraColorPresetsV2.GetRange(0, PluginConfig.Instance.ExtraColorPresetsV2.Count);
+        public static void ReinitUniqueSelectables()
+        {
+            ExtraColorPresetsUniqueSelectable = new List<string>();
+            PluginConfig.Instance.ExtraColorPresetsV2.ForEach(scheme =>
+            {
+                ExtraColorPresetsUniqueSelectable.Add(scheme.colorSchemeId);
+            });
         }
 
         [OnStart]

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -27,6 +27,8 @@ namespace BSExtraColorPresets
 
         private static readonly HarmonyLib.Harmony Harmony = new HarmonyLib.Harmony($"art.djdavid98.{PluginName}");
 
+        public static List<ExtraColorPresetV2> ExtraColorPresetsUniqueSelectable;
+
         [Init]
         /// <summary>
         /// Called when the plugin is first loaded by IPA (either when the game starts or when the plugin is enabled if it starts disabled).
@@ -53,6 +55,8 @@ namespace BSExtraColorPresets
                 Log.Debug("Adding initial blank preset");
                 PluginConfig.Instance.ExtraColorPresetsV2.Add(new ExtraColorPresetV2());
             }
+
+            ExtraColorPresetsUniqueSelectable = PluginConfig.Instance.ExtraColorPresetsV2.GetRange(0, PluginConfig.Instance.ExtraColorPresetsV2.Count);
         }
 
         [OnStart]

--- a/UI/MinimalExtraColorPreset.cs
+++ b/UI/MinimalExtraColorPreset.cs
@@ -6,7 +6,7 @@
         public string name { get; }
 
         public static readonly MinimalExtraColorPreset randomItem = new MinimalExtraColorPreset("Random", "random");
-        public static readonly MinimalExtraColorPreset randomUniqueItem = new MinimalExtraColorPreset("Random (Unique)", "randomUnique");
+        public static readonly MinimalExtraColorPreset randomUniqueItem = new MinimalExtraColorPreset("Shuffle", "randomUnique");
 
         public MinimalExtraColorPreset(ExtraColorPresetV2 preset)
         {

--- a/UI/MinimalExtraColorPreset.cs
+++ b/UI/MinimalExtraColorPreset.cs
@@ -6,6 +6,7 @@
         public string name { get; }
 
         public static readonly MinimalExtraColorPreset randomItem = new MinimalExtraColorPreset("Random", "random");
+        public static readonly MinimalExtraColorPreset randomUniqueItem = new MinimalExtraColorPreset("Random (Unique)", "randomUnique");
 
         public MinimalExtraColorPreset(ExtraColorPresetV2 preset)
         {

--- a/UI/PresetManagerSettings.cs
+++ b/UI/PresetManagerSettings.cs
@@ -90,6 +90,7 @@ namespace BSExtraColorPresets.UI
             var newPreset = new ExtraColorPresetV2();
             newPreset.name = ExtraColorPresetV2.GenerateName(PluginConfig.Instance.ExtraColorPresetsV2.Count());
             PluginConfig.Instance.ExtraColorPresetsV2.Add(newPreset);
+            Plugin.ExtraColorPresetsUniqueSelectable.Add(newPreset.colorSchemeId);
             UpdatePresetList();
         }
 
@@ -148,6 +149,10 @@ namespace BSExtraColorPresets.UI
         {
             if (modalEditingPreset != null)
             {
+                if (Plugin.ExtraColorPresetsUniqueSelectable.Contains(modalEditingPreset.colorSchemeId))
+                {
+                    Plugin.ExtraColorPresetsUniqueSelectable.Remove(modalEditingPreset.colorSchemeId);   
+                }
                 PluginConfig.Instance.ExtraColorPresetsV2.Remove(modalEditingPreset);
             }
             ClosePresetDeleteAction();

--- a/UI/PresetSelectorSettings.cs
+++ b/UI/PresetSelectorSettings.cs
@@ -43,7 +43,12 @@ namespace BSExtraColorPresets.UI
                 {
                     return selectedPreset;
                 }
-
+                
+                if (PluginConfig.Instance.SelectedPresetId == MinimalExtraColorPreset.randomUniqueItem.colorSchemeId)
+                {
+                    return MinimalExtraColorPreset.randomUniqueItem;
+                }
+                
                 return MinimalExtraColorPreset.randomItem;
             }
             set { PluginConfig.Instance.SelectedPresetId = value.colorSchemeId; }
@@ -78,7 +83,8 @@ namespace BSExtraColorPresets.UI
         {
             var list = new List<object>
             {
-                MinimalExtraColorPreset.randomItem
+                MinimalExtraColorPreset.randomItem,
+                MinimalExtraColorPreset.randomUniqueItem
             };
             list.AddRange(PluginConfig.Instance.ExtraColorPresetsV2);
             return list;


### PR DESCRIPTION
Wanted an option to ensure every random preset selected was unique (no presets being selected back to back), would commonly hit duplicates just by using random index positions.
Added it in as a selectable option.

(Unsure if there's a better place to store the ExtraColorPresetsUniqueSelectable List, seemed like the best spot if I wanted it maintained across the game session)